### PR TITLE
Add category choices to CLI help

### DIFF
--- a/promptlib.py
+++ b/promptlib.py
@@ -151,7 +151,12 @@ def main():
         description="Red Team Prompt Mutation Engine (promptlib.py)"
     )
     parser.add_argument("--tui", action="store_true", help="Run interactive TUI mode")
-    parser.add_argument("--category", type=str, help="Category key for batch mode")
+    parser.add_argument(
+        "--category",
+        type=str,
+        choices=list(TEMPLATES.keys()),
+        help="Category key for batch mode",
+    )
     parser.add_argument(
         "--count", type=int, default=5, help="Number of prompts (batch mode)"
     )

--- a/promptlib.sh
+++ b/promptlib.sh
@@ -23,7 +23,11 @@ usage() {
     echo "  --tui                    Run interactive TUI mode"
     echo
     echo "Available categories:"
-    $PYTHON_BIN $SCRIPT_NAME --help | grep "choices=" | sed 's/.*choices=//' | tr -d '[],' | tr "'" "\n" | awk '{$1=$1};1' | grep -v "^$" | sort | uniq
+    $PYTHON_BIN - <<'EOF'
+from prompt_config import load_config
+for name in sorted(load_config()[0].keys()):
+    print(name)
+EOF
 }
 
 # -----------
@@ -108,4 +112,5 @@ if [[ $STATUS -eq 0 ]]; then
 else
     echo "[ERROR] Prompt generation failed (exit code $STATUS)"
 fi
+
 


### PR DESCRIPTION
## Summary
- show available categories in `promptlib.py` argument help
- list categories directly in `promptlib.sh` help

## Testing
- `ruff check .`
- `black .`
- `PYTHONPATH=. pytest -q`
- `PYTHONPATH=. pytest --cov=promptlib_redteam -q` *(fails: unrecognized arguments)*
- `bash promptlib.sh --help`

------
https://chatgpt.com/codex/tasks/task_e_684ef58d2ebc832e9bf8d7322a9161c9