### PR TITLE
Add pre-commit tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.1
+    hooks:
+      - id: ruff
+        args: [--fix]
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: local
+    hooks:
+      - id: codex-merge-clean
+        name: codex-merge-clean
+        entry: bash 0-tests/codex-merge-clean.sh
+        language: script
+        pass_filenames: true
+        files: ''
+      - id: pytest
+        name: pytest
+        entry: bash -c 'PYTHONPATH=. pytest -q'
+        language: system
+        types: [python]
+
+

--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Unreleased
+- add pyproject with ruff and black config
+- add pre-commit config running ruff, black, pytest, and codex-merge-clean
+- document workflow in README
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# 4ndr0prompts
+
+This repository contains utilities for generating and testing red-team prompt mutations. Development follows strict linting and testing rules.
+
+## Setup
+
+1. Install the development dependencies:
+   ```bash
+   pip install -r requirements.txt  # if available
+   pip install pre-commit
+   ```
+2. Install the pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+
+## Development Workflow
+
+- All code changes must pass **ruff**, **black**, **pytest**, and the merge-artifact scrubber `0-tests/codex-merge-clean.sh`.
+- The hooks run automatically via pre-commit and should also run in CI for every pull request that modifies code files.
+- Documentation-only updates can skip these checks, but mixed changes run the full suite.
+
+Run all checks manually with:
+
+```bash
+pre-commit run --all-files
+```
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 88
+target-version = ['py310']
+
+[tool.ruff]
+line-length = 88
+target-version = 'py310'
+
+


### PR DESCRIPTION
## Summary
- configure ruff and black in `pyproject.toml`
- add `.pre-commit-config.yaml` running ruff, black, pytest and merge cleanup
- document development workflow in README
- note change in `0-tests/CHANGELOG.md`

## Testing
- `ruff check --fix .`
- `black .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef5a1e3ac832eb015c344f8c2a4a1