### PR TITLE
Update log path for prompt auditing

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -2,5 +2,6 @@
 - add pyproject with ruff and black config
 - add pre-commit config running ruff, black, pytest, and codex-merge-clean
 - document workflow in README
+- change default log directory to XDG data path and update tests
 
 

--- a/promptlib.py
+++ b/promptlib.py
@@ -20,6 +20,12 @@ import datetime
 import json
 from prompt_config import load_config
 
+DEFAULT_LOG_DIR = os.path.join(
+    os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share")),
+    "redteam-prompts",
+    "logs",
+)
+
 # ANSI color support for cyan highlights
 CYAN = "\033[36m"
 RESET = "\033[0m"
@@ -115,7 +121,7 @@ def save_structured(prompts, category, slotsets, output_path):
                 f.write(f"  {slot}: {value}\n")
 
 
-def log_prompts(prompts, category, slotsets, output_path=None, log_dir="prompt_logs"):
+def log_prompts(prompts, category, slotsets, output_path=None, log_dir=DEFAULT_LOG_DIR):
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     if not output_path:
         output_path = f"prompts_{category}_{timestamp}.txt"

--- a/promptlib_cli.py
+++ b/promptlib_cli.py
@@ -19,6 +19,12 @@ from prompt_toolkit.styles import Style
 from prompt_toolkit.completion import PathCompleter
 from prompt_config import generate_prompt, load_config
 
+DEFAULT_LOG_DIR = os.path.join(
+    os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share")),
+    "redteam-prompts",
+    "logs",
+)
+
 # ---- Defensive promptlib import ----
 try:
     import promptlib
@@ -58,7 +64,7 @@ def write_previewed_prompts(category, prompts, output_path):
         for idx, p in enumerate(prompts, 1):
             f.write(f"{idx}. {p}\n\n")
     # Also audit
-    audit_dir = "prompt_logs"
+    audit_dir = DEFAULT_LOG_DIR
     safe_ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     os.makedirs(audit_dir, exist_ok=True)
     with open(os.path.join(audit_dir, "prompt_audit.log"), "a") as log:
@@ -160,7 +166,9 @@ def main():
     # Final message
     message_dialog(
         title="PromptLib CLI Done",
-        text="Prompt generation complete.\nAudit: prompt_logs/prompt_audit.log",
+        text=(
+            "Prompt generation complete.\nAudit: " f"{DEFAULT_LOG_DIR}/prompt_audit.log"
+        ),
         style=style,
     ).run()
 
@@ -171,4 +179,3 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         print("\nAborted.")
         sys.exit(0)
-

--- a/promptlib_interactive.py
+++ b/promptlib_interactive.py
@@ -15,11 +15,16 @@ import json
 import random
 import datetime
 import argparse
-
 from prompt_toolkit.shortcuts import radiolist_dialog
 from prompt_toolkit.styles import Style
 from prompt_toolkit import print_formatted_text, HTML
 from prompt_config import load_config
+
+DEFAULT_LOG_DIR = os.path.join(
+    os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share")),
+    "redteam-prompts",
+    "logs",
+)
 
 # ===================== Style for cyan highlights ======================
 style = Style.from_dict(
@@ -100,7 +105,7 @@ def format_structured_output(prompts, slotset, output_path):
             f.write(f"{row} | {p}\n")
 
 
-def log_prompts(prompts, category, slotset, output_path=None, log_dir="prompt_logs"):
+def log_prompts(prompts, category, slotset, output_path=None, log_dir=DEFAULT_LOG_DIR):
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     if not output_path:
         output_path = f"prompts_{category}_{timestamp}.txt"

--- a/tests/test_promptlib2.py
+++ b/tests/test_promptlib2.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import os
 
 import promptlib2
 
@@ -25,3 +26,13 @@ def test_cli_dry_run():
     )
     assert result.returncode == 0
     assert result.stdout.strip()
+
+
+def test_default_log_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    import importlib
+
+    promptlib = importlib.import_module("promptlib")
+    importlib.reload(promptlib)
+    expected = os.path.join(tmp_path, "redteam-prompts", "logs")
+    assert promptlib.DEFAULT_LOG_DIR == expected


### PR DESCRIPTION
## Summary
- set XDG compliant log directory in `promptlib` modules
- ensure CLI audit message points to new location
- create constant for default log directory
- adjust unit tests for new path
- note change in changelog

## Testing
- `ruff check --fix promptlib.py promptlib_cli.py promptlib_interactive.py tests/test_promptlib2.py`
- `black promptlib.py promptlib_cli.py promptlib_interactive.py tests/test_promptlib2.py`
- `PYTHONPATH=. pytest -q`
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684efba9c088832e8617ed983af5ecc4