### PR TITLE
Fix generate_prompt API

### DIFF
--- a/promptlib.py
+++ b/promptlib.py
@@ -152,6 +152,12 @@ def random_prompt(template, slotset):
     return result, selected
 
 
+def generate_prompt(template, slotset):
+    """Return a prompt with slots filled randomly."""
+    prompt, _ = random_prompt(template, slotset)
+    return prompt
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Red Team Prompt Mutation Engine (promptlib.py)"

--- a/tests/test_promptlib.py
+++ b/tests/test_promptlib.py
@@ -1,0 +1,17 @@
+import promptlib
+
+
+def test_generate_prompt_wrapper():
+    template = "Hello [NAME]"
+    slots = {"NAME": ["Alice", "Bob"]}
+    result = promptlib.generate_prompt(template, slots)
+    assert result in {"Hello Alice", "Hello Bob"}
+
+
+def test_random_prompt_selection():
+    template = "Hi [WHO]"
+    slots = {"WHO": ["A", "B"]}
+    prompt, selected = promptlib.random_prompt(template, slots)
+    assert prompt in {"Hi A", "Hi B"}
+    assert selected
+    assert selected["WHO"] in {"A", "B"}


### PR DESCRIPTION
## Summary
- restore `generate_prompt` wrapper in `promptlib.py`
- add unit tests for new wrapper and `random_prompt`

Function count:
- **promptlib.py**: 7 functions, 206 lines
- **tests/test_promptlib.py**: 2 functions, 17 lines

## Testing
- `ruff check --fix promptlib.py tests/test_promptlib.py`
- `black promptlib.py tests/test_promptlib.py`
- `PYTHONPATH=. pytest -q`
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f042e2b08832e8660d4ef2a1de2b0