### PR TITLE
Add category listing to CLI and remove eval use

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -3,6 +3,8 @@
 - add pre-commit config running ruff, black, pytest, and codex-merge-clean
 - document workflow in README
 - integrate shellcheck into pre-commit hooks and expand README instructions
+- promptlib.py exposes --list-categories and promptlib.sh drops eval usage
+
 
 
 

--- a/promptlib.py
+++ b/promptlib.py
@@ -158,6 +158,11 @@ def main():
     )
     parser.add_argument("--tui", action="store_true", help="Run interactive TUI mode")
     parser.add_argument(
+        "--list-categories",
+        action="store_true",
+        help="List available prompt categories and exit",
+    )
+    parser.add_argument(
         "--category",
         type=str,
         choices=list(TEMPLATES.keys()),
@@ -173,6 +178,11 @@ def main():
     args = parser.parse_args()
 
     color = not args.no_color
+
+    if args.list_categories:
+        for cat in sorted(TEMPLATES.keys()):
+            print(cat)
+        sys.exit(0)
 
     if args.tui:
         interactive_prompt(enable_color=color)

--- a/promptlib.sh
+++ b/promptlib.sh
@@ -27,11 +27,7 @@ usage() {
     printf '  --tui                    Run interactive TUI mode\n'
     printf '\n'
     printf 'Available categories:\n'
-    $PYTHON_BIN - <<'EOF'
-from prompt_config import load_config
-for name in sorted(load_config()[0].keys()):
-    print(name)
-EOF
+    "$PYTHON_BIN" "$SCRIPT_NAME" --list-categories
 }
 
 # -----------
@@ -84,11 +80,11 @@ done
 # -----------
 
 if [[ "$TUI_MODE" -eq 1 ]]; then
-    CMD="$PYTHON_BIN $SCRIPT_NAME --tui"
+    cmd=("$PYTHON_BIN" "$SCRIPT_NAME" "--tui")
     if [[ "$NO_COLOR" -eq 1 ]]; then
-        CMD="$CMD --no-color"
+        cmd+=("--no-color")
     fi
-    eval $CMD
+    "${cmd[@]}"
     exit $?
 fi
 
@@ -98,15 +94,15 @@ if [[ -z "$CATEGORY" ]]; then
     exit 1
 fi
 
-CMD="$PYTHON_BIN $SCRIPT_NAME --category $CATEGORY --count $COUNT"
+cmd=("$PYTHON_BIN" "$SCRIPT_NAME" "--category" "$CATEGORY" "--count" "$COUNT")
 if [[ -n "$OUTPUT" ]]; then
-    CMD="$CMD --output \"$OUTPUT\""
+    cmd+=("--output" "$OUTPUT")
 fi
 if [[ "$NO_COLOR" -eq 1 ]]; then
-    CMD="$CMD --no-color"
+    cmd+=("--no-color")
 fi
 
-eval $CMD
+"${cmd[@]}"
 STATUS=$?
 if [[ $STATUS -eq 0 ]]; then
     printf '[SUCCESS] Prompts generated for category %s.\n' "$CATEGORY"
@@ -119,4 +115,5 @@ else
     printf '[ERROR] Prompt generation failed (exit code %s)\n' "$STATUS"
     printf '%s [ERROR] exit=%s\n' "$(date -Is)" "$STATUS" >>"$LOG_FILE"
 fi
+
 


### PR DESCRIPTION
## Summary
- expose `--list-categories` in `promptlib.py`
- call the new option from `promptlib.sh` and replace `eval` logic

## Testing
- `ruff check --fix promptlib.py`
- `black promptlib.py`
- `PYTHONPATH=. pytest -q`
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f04355c54832e9197e38a13885ac1