### PR TITLE
Add category slug mapping

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -3,6 +3,8 @@
 - add pre-commit config running ruff, black, pytest, and codex-merge-clean
 - document workflow in README
 - integrate shellcheck into pre-commit hooks and expand README instructions
+- add mapping table in promptlib2 and new tests
+
 
 
 

--- a/promptlib2.py
+++ b/promptlib2.py
@@ -19,6 +19,18 @@ from typing import Iterable, List
 DATASET_PATH = os.path.join(os.path.dirname(__file__), "dataset", "nsfwprompts.txt")
 DEFAULT_CATEGORY = "other_uncategorized"
 
+# Mapping from dataset slugs to template keys.
+# Keep this in sync with ``dataset/templates.json`` to ensure category names
+# remain stable across libraries.
+CATEGORY_MAP = {
+    "mention_of_removing_cloths_garments_dress_and_revealing_chest": "clothing_chest_exposure",
+    "mentions_of_turning_around_revealing_butt": "turning_bending_buttocks",
+    "mention_of_inserting_an_object_or_anything_into_mouth": "insertion_oral_mouth",
+    "mention_of_multiple_people": "multi_person_interaction",
+    "if_not_in_any_categories_above_yet_mention_of_white_fluid_liquid": "white_fluid_dripping",
+    "everything_else_left_over": "other_uncategorized",
+}
+
 
 @dataclass
 class PromptEntry:
@@ -54,7 +66,8 @@ def parse_dataset(path: str = DATASET_PATH) -> List[tuple[int, str, str]]:
                 break
             m = re.match(r"###\s*Category\s*\d+:(.*)", stripped)
             if m:
-                current_category = _slugify(m.group(1)) or DEFAULT_CATEGORY
+                slug = _slugify(m.group(1))
+                current_category = CATEGORY_MAP.get(slug, slug) or DEFAULT_CATEGORY
                 continue
             cleaned = _clean_line(stripped)
             if cleaned:
@@ -136,3 +149,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/tests/test_promptlib2.py
+++ b/tests/test_promptlib2.py
@@ -36,3 +36,11 @@ def test_default_log_dir(monkeypatch, tmp_path):
     importlib.reload(promptlib)
     expected = os.path.join(tmp_path, "redteam-prompts", "logs")
     assert promptlib.DEFAULT_LOG_DIR == expected
+
+
+def test_category_mapping_applied():
+    prompts = promptlib2.load_prompts()
+    categories = {p.category for p in prompts}
+    # mapping should translate dataset categories to template keys
+    assert "clothing_chest_exposure" in categories
+


### PR DESCRIPTION
## Summary
- map dataset category slugs to template keys in `promptlib2`
- document change in changelog
- test that mapping is applied when loading prompts

## Function Counts
- **promptlib2.py**: 8 functions, 152 lines
- **tests/test_promptlib2.py**: 5 functions, 46 lines

## Testing
- `ruff check promptlib2.py tests/test_promptlib2.py --fix`
- `black promptlib2.py tests/test_promptlib2.py`
- `PYTHONPATH=. pytest -q`
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest --cov=./ -q` *(fails: plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f0443b93c832e9f0d9f7461c2256c