### PR TITLE
Add utf-8 encoding for write operations

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -13,3 +13,5 @@
 
 
 
+- enforce utf-8 encoding for file writes
+

--- a/promptlib.py
+++ b/promptlib.py
@@ -111,7 +111,7 @@ def interactive_prompt(enable_color=True):
 
 
 def save_structured(prompts, category, slotsets, output_path):
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         for idx, (prompt, slots) in enumerate(zip(prompts, slotsets), 1):
             f.write("---\n")
             f.write(f"prompt_{idx}:\n")

--- a/promptlib_cli.py
+++ b/promptlib_cli.py
@@ -57,7 +57,7 @@ def ensure_output_dir(category):
 
 def write_previewed_prompts(category, prompts, output_path):
     timestamp = now_str()
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(f"# Category: {category}\n")
         f.write(f"# Generated: {timestamp}\n")
         f.write(f"# Prompt Count: {len(prompts)}\n\n")

--- a/promptlib_interactive.py
+++ b/promptlib_interactive.py
@@ -96,7 +96,7 @@ def format_structured_output(prompts, slotset, output_path):
     headers = list(slotset.keys())
     header_line = " | ".join(f"{h:^18}" for h in headers) + " | PROMPT"
     sep = "-" * (len(header_line) + 5)
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(f"{header_line}\n{sep}\n")
         for p in prompts:
             row = " | ".join(


### PR DESCRIPTION
## Summary
- ensure output uses UTF-8 when writing prompts
- update changelog

## Testing
- `ruff check --fix promptlib.py promptlib_cli.py promptlib_interactive.py`
- `black promptlib.py promptlib_cli.py promptlib_interactive.py`
- `PYTHONPATH=. pytest -q`
- `pytest --cov=./` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68509b1db0c0832ea27b9b88b1db1a69