### PR TITLE
Fix trailing blank line

### DIFF
--- a/promptlib_tui.py
+++ b/promptlib_tui.py
@@ -286,4 +286,3 @@ if __name__ == "__main__":
         safe_cli_menu()
     else:
         PromptGenApp().run()
-


### PR DESCRIPTION
## Summary
- remove trailing blank line from promptlib_tui.py

File stats for `promptlib_tui.py`:
- 6 functions
- 288 lines

## Testing
- `ruff check --fix promptlib_tui.py`
- `black promptlib_tui.py`
- `PYTHONPATH=. pytest -q`
- `pytest --cov=.` *(fails: unrecognized arguments --cov=.)*


------
https://chatgpt.com/codex/tasks/task_e_6850a43b28d0832eb16be034be72697b