### PR TITLE
Remove outdated requirements.txt mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This repository contains utilities for generating and testing red-team prompt mu
 
 1. Install the development dependencies:
    ```bash
-   pip install -r requirements.txt  # if available
    pip install pre-commit ruff black pytest shellcheck
    ```
 2. Install the pre-commit hooks:
@@ -27,3 +26,4 @@ Run all checks manually with:
 ```bash
 pre-commit run --all-files
 ```
+


### PR DESCRIPTION
## Summary
- update README to remove reference to a missing requirements.txt

## Testing
- `0-tests/codex-merge-clean.sh README.md`
- `.venv-codex/bin/pre-commit run --files README.md` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6850a438c23c832eab16cf543975ca5a