### PR TITLE
Fix POSIX compatibility for promptlib.sh

### DIFF
--- a/promptlib.sh
+++ b/promptlib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # promptlib.sh - Production-ready shell wrapper for promptlib.py
 set -euo pipefail
 
@@ -42,24 +42,24 @@ OUTPUT=""
 NO_COLOR=0
 DRY_RUN=0
 
-while [[ $# -gt 0 ]]; do
+while [ "$#" -gt 0 ]; do
     key="$1"
-    case $key in
+    case "$key" in
         --tui)
             TUI_MODE=1
             shift
             ;;
         --category)
             CATEGORY="$2"
-            shift; shift
+            shift 2
             ;;
         --count)
             COUNT="$2"
-            shift; shift
+            shift 2
             ;;
         --output)
             OUTPUT="$DATA_HOME/$(basename "$2")"
-            shift; shift
+            shift 2
             ;;
         --no-color)
             NO_COLOR=1
@@ -85,51 +85,58 @@ done
 # MAIN LOGIC
 # -----------
 
-if [[ "$TUI_MODE" -eq 1 ]]; then
-    cmd=("$PYTHON_BIN" "$SCRIPT_NAME" "--tui")
-    if [[ "$NO_COLOR" -eq 1 ]]; then
-        cmd+=("--no-color")
+if [ "$TUI_MODE" -eq 1 ]; then
+    set -- "$PYTHON_BIN" "$SCRIPT_NAME" --tui
+    if [ "$NO_COLOR" -eq 1 ]; then
+        set -- "$@" --no-color
     fi
-    "${cmd[@]}"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '[DRY-RUN] %s\n' "$*"
+        exit 0
+    fi
+    "$@"
     exit $?
 fi
 
-if [[ -z "$CATEGORY" ]]; then
+if [ -z "$CATEGORY" ]; then
     printf '[ERROR] --category is required unless running --tui\n'
     usage
     exit 1
 fi
 
-cmd=("$PYTHON_BIN" "$SCRIPT_NAME" "--category" "$CATEGORY" "--count" "$COUNT")
-if [[ -n "$OUTPUT" ]]; then
-    cmd+=("--output" "$OUTPUT")
+set -- "$PYTHON_BIN" "$SCRIPT_NAME" --category "$CATEGORY" --count "$COUNT"
+if [ -n "$OUTPUT" ]; then
+    set -- "$@" --output "$OUTPUT"
 fi
-if [[ "$NO_COLOR" -eq 1 ]]; then
-    cmd+=("--no-color")
+if [ "$NO_COLOR" -eq 1 ]; then
+    set -- "$@" --no-color
 fi
 
-if [[ "$DRY_RUN" -eq 1 ]]; then
-    printf '[DRY-RUN] %s\n' "${cmd[*]}"
+if [ "$DRY_RUN" -eq 1 ]; then
+    printf '[DRY-RUN] %s\n' "$*"
     exit 0
 fi
 
-"${cmd[@]}"
+"$@"
 STATUS=$?
-if [[ $STATUS -eq 0 ]]; then
+if [ "$STATUS" -eq 0 ]; then
     printf '[SUCCESS] Prompts generated for category %s.\n' "$CATEGORY"
-    if [[ "$DRY_RUN" -eq 0 ]]; then
+    if [ "$DRY_RUN" -eq 0 ]; then
         printf '%s [SUCCESS] category=%s\n' "$(date -Is)" "$CATEGORY" >>"$LOG_FILE"
     fi
-    if [[ -n "$OUTPUT" ]]; then
+    if [ -n "$OUTPUT" ]; then
         printf '[INFO] See file: %s\n' "$OUTPUT"
-        if [[ "$DRY_RUN" -eq 0 ]]; then
+        if [ "$DRY_RUN" -eq 0 ]; then
             printf '%s [INFO] output=%s\n' "$(date -Is)" "$OUTPUT" >>"$LOG_FILE"
         fi
     fi
 else
     printf '[ERROR] Prompt generation failed (exit code %s)\n' "$STATUS"
-    if [[ "$DRY_RUN" -eq 0 ]]; then
+    if [ "$DRY_RUN" -eq 0 ]; then
         printf '%s [ERROR] exit=%s\n' "$(date -Is)" "$STATUS" >>"$LOG_FILE"
     fi
 fi
+
+
+
 


### PR DESCRIPTION
## Summary
- rewrite `promptlib.sh` to use `/bin/sh` syntax
- use `set --` and POSIX test constructs

Function count: 1
Line count: 142

## Testing
- `ruff check --fix .`
- `black .` *(fails: reformats unrelated file)*
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850a436105c832e9e6e6634967b1be0