### PR TITLE
Fix audit log path in ResultForm

### DIFF
--- a/promptlib_tui.py
+++ b/promptlib_tui.py
@@ -238,7 +238,7 @@ class ResultForm(npyscreen.FormBaseNew):
         )
         self.add(
             npyscreen.FixedText,
-            value="Audit logs in prompt_logs/prompt_audit.log",
+            value=f"Audit logs in {promptlib.DEFAULT_LOG_DIR}/prompt_audit.log",
             editable=False,
             relx=2,
             rely=3,


### PR DESCRIPTION
## Summary
- reference `promptlib.DEFAULT_LOG_DIR` in the TUI result message

Function count for `promptlib_tui.py`: 16
Line count for `promptlib_tui.py`: 289

Coverage information could not be generated because the `pytest-cov` plugin is missing in the environment.

## Testing
- `ruff check --fix .`
- `black .`
- `PYTHONPATH=. pytest -q`
- `pre-commit run --all-files` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850a4312a4c832eaa62209ce4c28a92