### PR TITLE
fix: ensure utf-8 encoding for file writes

### DIFF
--- a/promptlib.py
+++ b/promptlib.py
@@ -100,7 +100,7 @@ def interactive_prompt(enable_color=True):
     )
     if save == "y":
         outpath = f"interactive_prompt_{catkey}_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
-        with open(outpath, "w") as f:
+        with open(outpath, "w", encoding="utf-8") as f:
             f.write(f"category: {catkey}\n")
             f.write(f"prompt: {prompt}\n")
             for slot, value in slot_values.items():
@@ -127,7 +127,7 @@ def log_prompts(prompts, category, slotsets, output_path=None, log_dir=DEFAULT_L
         output_path = f"prompts_{category}_{timestamp}.txt"
     save_structured(prompts, category, slotsets, output_path)
     os.makedirs(log_dir, exist_ok=True)
-    with open(os.path.join(log_dir, "prompt_audit.log"), "a") as log:
+    with open(os.path.join(log_dir, "prompt_audit.log"), "a", encoding="utf-8") as log:
         for p, slots in zip(prompts, slotsets):
             slotjson = json.dumps(slots)
             log.write(f"{timestamp}\t{category}\t{p}\t{slotjson}\n")
@@ -214,3 +214,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/promptlib_cli.py
+++ b/promptlib_cli.py
@@ -67,7 +67,9 @@ def write_previewed_prompts(category, prompts, output_path):
     audit_dir = DEFAULT_LOG_DIR
     safe_ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     os.makedirs(audit_dir, exist_ok=True)
-    with open(os.path.join(audit_dir, "prompt_audit.log"), "a") as log:
+    with open(
+        os.path.join(audit_dir, "prompt_audit.log"), "a", encoding="utf-8"
+    ) as log:
         for p in prompts:
             log.write(f"{safe_ts}\t{category}\t{p}\n")
 
@@ -179,3 +181,4 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         print("\nAborted.")
         sys.exit(0)
+

--- a/promptlib_interactive.py
+++ b/promptlib_interactive.py
@@ -111,7 +111,7 @@ def log_prompts(prompts, category, slotset, output_path=None, log_dir=DEFAULT_LO
         output_path = f"prompts_{category}_{timestamp}.txt"
     format_structured_output(prompts, slotset, output_path)
     os.makedirs(log_dir, exist_ok=True)
-    with open(os.path.join(log_dir, "prompt_audit.log"), "a") as log:
+    with open(os.path.join(log_dir, "prompt_audit.log"), "a", encoding="utf-8") as log:
         for p in prompts:
             log.write(f"{timestamp}\t{category}\t{p}\n")
     return output_path
@@ -218,3 +218,4 @@ if __name__ == "__main__":
         interactive_main()
     else:
         cli_main()
+

--- a/promptlib_tui.py
+++ b/promptlib_tui.py
@@ -67,7 +67,7 @@ def ensure_output_dir(category):
 
 def write_previewed_prompts(category, prompts, output_path):
     timestamp = now_str()
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(f"# Category: {category}\n")
         f.write(f"# Generated: {timestamp}\n")
         f.write(f"# Prompt Count: {len(prompts)}\n\n")
@@ -77,7 +77,9 @@ def write_previewed_prompts(category, prompts, output_path):
     audit_dir = promptlib.DEFAULT_LOG_DIR
     safe_ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     os.makedirs(audit_dir, exist_ok=True)
-    with open(os.path.join(audit_dir, "prompt_audit.log"), "a") as log:
+    with open(
+        os.path.join(audit_dir, "prompt_audit.log"), "a", encoding="utf-8"
+    ) as log:
         for p in prompts:
             log.write(f"{safe_ts}\t{category}\t{p}\n")
 


### PR DESCRIPTION
## Summary
- add UTF-8 encoding to all `open(..., "w")` and `open(..., "a")` calls

Function counts / line counts:
- `promptlib.py`: 7 functions, 217 lines
- `promptlib_tui.py`: 6 functions, 291 lines
- `promptlib_interactive.py`: 7 functions, 221 lines
- `promptlib_cli.py`: 6 functions, 184 lines

## Testing
- `ruff check --fix .`
- `black .`
- `PYTHONPATH=. pytest -q`
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a4300b00832e9ffb9a1eca2e3969