### PR TITLE
Implement path-specific caching for load_config

### DIFF
--- a/prompt_config.py
+++ b/prompt_config.py
@@ -8,23 +8,26 @@ import os
 import random
 from typing import Dict
 
-CONFIG_PATH = os.path.join(os.path.dirname(__file__), "dataset", "templates.json")
+_CACHE: dict[str, tuple[Dict[str, str], Dict[str, Dict[str, list]]]] = {}
 
-_templates: Dict[str, str] | None = None
-_slots: Dict[str, Dict[str, list]] | None = None
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "dataset", "templates.json")
 
 
 def load_config(
     path: str = CONFIG_PATH,
 ) -> tuple[Dict[str, str], Dict[str, Dict[str, list]]]:
-    """Load templates and slots from JSON configuration."""
-    global _templates, _slots
-    if _templates is None or _slots is None:
-        with open(path, "r", encoding="utf-8") as fh:
+    """Load templates and slots from JSON configuration.
+
+    Results are cached per absolute path to avoid repeated file reads.
+    """
+    abspath = os.path.abspath(path)
+    if abspath not in _CACHE:
+        with open(abspath, "r", encoding="utf-8") as fh:
             data = json.load(fh)
-        _templates = data.get("templates", {})
-        _slots = data.get("slots", {})
-    return _templates, _slots
+        templates = data.get("templates", {})
+        slots = data.get("slots", {})
+        _CACHE[abspath] = (templates, slots)
+    return _CACHE[abspath]
 
 
 def generate_prompt(template: str, slots: Dict[str, list]) -> str:


### PR DESCRIPTION
## Summary
- cache configurations by absolute path in `prompt_config.load_config`

## Testing
- `ruff check --fix prompt_config.py`
- `black prompt_config.py`
- `PYTHONPATH=. pytest -q`
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ae30bec8832eb35b8f68303a4c6d