### PR TITLE
Implement rawdata parser and default TUI

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -14,3 +14,5 @@
 
 
 
+- implement parse_rawdata.py with category heuristics and slot extraction; add tests
+

--- a/README.md
+++ b/README.md
@@ -33,5 +33,7 @@ To regenerate the template dataset in verbatim mode:
 PYTHONPATH=. python scripts/parse_rawdata.py --write --trim-sentences 1
 ```
 
+`prompts.sh` launches the TUI by default. Use `--cli` to run the minimal CLI mode.
+
 
 

--- a/prompts.sh
+++ b/prompts.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 # promptlib.sh - Production-ready shell wrapper for promptlib.py
-set -euo 
+set -euo
 
 # -----------
 # CONFIGURATION
 # -----------
 
 PYTHON_BIN="python3"
-SCRIPT_NAME="promptlib.py"
+TUI_SCRIPT="tests/ui/promptlib_tui.py"
+CLI_SCRIPT="promptlib.py"
 DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/prompts.sh"
 LOG_FILE="$DATA_HOME/prompts_sh.log"
 mkdir -p "$DATA_HOME"
@@ -17,25 +18,24 @@ mkdir -p "$DATA_HOME"
 # -----------
 
 usage() {
-    printf 'Usage: %s --category <category> [--count N] [--output FILE] [--no-color] [--dry-run]\n' "$0"
-    printf '       %s --tui [--no-color] [--dry-run]\n' "$0"
+    printf 'Usage: %s [--cli --category <category> [--count N] [--output FILE]] [--no-color] [--dry-run]\n' "$0"
     printf '\n'
-    printf '  --category <category>    Category key (batch mode, e.g. clothing_chest_exposure)\n'
+    printf '  --cli                    Run minimal CLI instead of default TUI\n'
+    printf '  --category <category>    Category key for CLI mode\n'
     printf '  --count N                Number of prompts to generate (default: 5)\n'
     printf '  --output FILE            Output file saved under %s\n' "$DATA_HOME"
     printf '  --no-color               Disable cyan output highlighting\n'
     printf '  --dry-run                Print command without executing\n'
-    printf '  --tui                    Run interactive TUI mode\n'
     printf '\n'
     printf 'Available categories:\n'
-    "$PYTHON_BIN" "$SCRIPT_NAME" --list-categories
+    "$PYTHON_BIN" "$TUI_SCRIPT" --simple-cli --list-categories
 }
 
 # -----------
 # ARGUMENT PARSING
 # -----------
 
-TUI_MODE=0
+CLI_MODE=0
 CATEGORY=""
 COUNT=5
 OUTPUT=""
@@ -45,8 +45,8 @@ DRY_RUN=0
 while [ "$#" -gt 0 ]; do
     key="$1"
     case "$key" in
-        --tui)
-            TUI_MODE=0
+        --cli)
+            CLI_MODE=1
             shift
             ;;
         --category)
@@ -85,8 +85,8 @@ done
 # MAIN LOGIC
 # -----------
 
-if [ "$TUI_MODE" -eq 1 ]; then
-    set -- "$PYTHON_BIN" "$SCRIPT_NAME" --tui
+if [ "$CLI_MODE" -eq 0 ]; then
+    set -- "$PYTHON_BIN" "$TUI_SCRIPT"
     if [ "$NO_COLOR" -eq 1 ]; then
         set -- "$@" --no-color
     fi
@@ -99,12 +99,11 @@ if [ "$TUI_MODE" -eq 1 ]; then
 fi
 
 if [ -z "$CATEGORY" ]; then
-    printf '[ERROR] --category is required unless running --tui\n'
+    printf '[ERROR] --category is required with --cli\n'
     usage
     exit 1
 fi
-
-set -- "$PYTHON_BIN" "$SCRIPT_NAME" --category "$CATEGORY" --count "$COUNT"
+set -- "$PYTHON_BIN" "$CLI_SCRIPT" --category "$CATEGORY" --count "$COUNT"
 if [ -n "$OUTPUT" ]; then
     set -- "$@" --output "$OUTPUT"
 fi
@@ -136,3 +135,5 @@ else
         printf '%s [ERROR] exit=%s\n' "$(date -Is)" "$STATUS" >>"$LOG_FILE"
     fi
 fi
+
+

--- a/scripts/parse_rawdata.py
+++ b/scripts/parse_rawdata.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Parse raw dataset and generate templates and slot reports."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from typing import Dict, Iterable, List
+
+RAWDATA_PATH = os.path.join(os.path.dirname(__file__), "..", "dataset", "rawdata.txt")
+
+CATEGORY_RULES = {
+    "turning_bending_buttocks": re.compile(r"buttocks|culo|rear", re.I),
+    "clothing_chest_exposure": re.compile(r"breast|chest|areola", re.I),
+    "insertion_oral_mouth": re.compile(r"mouth|suck|oral", re.I),
+    "multi_person_interaction": re.compile(
+        r"kiss|touch|caress|stroke|hold|embrace", re.I
+    ),
+    "white_fluid_dripping": re.compile(r"fluid|liquid|esperma|yfluid", re.I),
+}
+DEFAULT_CATEGORY = "other_uncategorized"
+
+SLOT_PATTERNS: Dict[str, Dict[str, re.Pattern[str]]] = {
+    "turning_bending_buttocks": {
+        "CLOTHING_BOTTOM": re.compile(r"skirt|pants|trunks|leggings?|tanga", re.I),
+        "BUTTOCKS_DESC": re.compile(
+            r"round buttocks|bare buttocks|bottom|backside|thighs", re.I
+        ),
+    },
+    "clothing_chest_exposure": {
+        "ACTION": re.compile(r"drool|smack|lean|dance|jiggle|sway|grope", re.I),
+    },
+    "white_fluid_dripping": {
+        "LIQUID_DESC": re.compile(r"pearly|milky|viscous|ropey|stringy|yfluid", re.I),
+    },
+    "multi_person_interaction": {
+        "INTERACTION": re.compile(
+            r"kiss(?:es)?|touch|caress|stroke|hold|embrace", re.I
+        ),
+    },
+}
+
+
+def _read_raw(path: str) -> List[str]:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return [line.strip() for line in fh if line.strip()]
+    except FileNotFoundError:
+        print(f"File not found: {path}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _categorize(text: str) -> str:
+    for cat, pattern in CATEGORY_RULES.items():
+        if pattern.search(text):
+            return cat
+    return DEFAULT_CATEGORY
+
+
+def _extract_slots(text: str, category: str) -> Dict[str, List[str]]:
+    slots: Dict[str, List[str]] = {}
+    patterns = SLOT_PATTERNS.get(category, {})
+    for name, pattern in patterns.items():
+        values = sorted({m.group(0).strip() for m in pattern.finditer(text)})
+        if values:
+            slots[name] = values
+    return slots
+
+
+def parse_lines(lines: Iterable[str], trim_sentences: int = 1):
+    templates: Dict[str, str] = {}
+    slots: Dict[str, Dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    for line in lines:
+        category = _categorize(line)
+        first_sent = ".".join(line.split(".")[:trim_sentences]).strip()
+        templates.setdefault(category, first_sent)
+        slot_values = _extract_slots(line, category)
+        for slot, vals in slot_values.items():
+            slots[category][slot].update(vals)
+    # convert sets to sorted lists
+    final_slots = {
+        cat: {s: sorted(list(vals)) for s, vals in sd.items()}
+        for cat, sd in slots.items()
+    }
+    for cat in CATEGORY_RULES:
+        final_slots.setdefault(cat, {})
+        templates.setdefault(cat, templates.get(cat, ""))
+    final_slots.setdefault(DEFAULT_CATEGORY, {})
+    templates.setdefault(DEFAULT_CATEGORY, templates.get(DEFAULT_CATEGORY, ""))
+    return templates, final_slots
+
+
+def write_outputs(
+    templates: Dict[str, str], slots: Dict[str, Dict[str, List[str]]], output_dir: str
+) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    out_json = os.path.join(output_dir, "templates.json")
+    with open(out_json, "w", encoding="utf-8") as fh:
+        json.dump({"templates": templates, "slots": slots}, fh, indent=2)
+    report = os.path.join(output_dir, "slots_report.tsv")
+    with open(report, "w", encoding="utf-8") as fh:
+        for cat, slot_map in slots.items():
+            for slot, values in slot_map.items():
+                for val in values:
+                    val = val.replace("\t", "\\t").replace("\n", " ")
+                    fh.write(f"{cat}\t{slot}\t{val}\n")
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Parse raw dataset")
+    parser.add_argument(
+        "--write", action="store_true", help="Write outputs to dataset directory"
+    )
+    parser.add_argument(
+        "--trim-sentences",
+        type=int,
+        default=1,
+        help="Number of sentences to keep for templates",
+    )
+    parser.add_argument(
+        "--output-dir", default=os.path.join(os.path.dirname(__file__), "..", "dataset")
+    )
+    args = parser.parse_args(argv)
+
+    lines = _read_raw(RAWDATA_PATH)
+    templates, slots = parse_lines(lines, args.trim_sentences)
+    if args.write:
+        write_outputs(templates, slots, args.output_dir)
+    else:
+        print(json.dumps({"templates": templates, "slots": slots}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_rawdata_parse.py
+++ b/tests/test_rawdata_parse.py
@@ -1,0 +1,29 @@
+from scripts import parse_rawdata
+
+
+def test_all_categories_accounted():
+    lines = parse_rawdata._read_raw(parse_rawdata.RAWDATA_PATH)
+    templates, slots = parse_rawdata.parse_lines(lines, trim_sentences=1)
+    for cat in list(parse_rawdata.CATEGORY_RULES.keys()) + [
+        parse_rawdata.DEFAULT_CATEGORY
+    ]:
+        assert cat in templates
+        assert cat in slots
+
+
+def test_no_empty_slot_lists(tmp_path):
+    out_dir = tmp_path
+    parse_rawdata.write_outputs({"a": "b"}, {"a": {"S": ["x"]}}, out_dir)
+    report = out_dir / "slots_report.tsv"
+    assert report.exists()
+    lines = report.read_text().splitlines()
+    for line in lines:
+        assert len(line.split("\t")) == 3
+
+
+def test_no_duplicate_slot_values():
+    lines = parse_rawdata._read_raw(parse_rawdata.RAWDATA_PATH)
+    _, slots = parse_rawdata.parse_lines(lines)
+    for cat, slot_map in slots.items():
+        for values in slot_map.values():
+            assert len(values) == len(set(values))


### PR DESCRIPTION
## Summary
- add `scripts/parse_rawdata.py` with category heuristics and slot extraction
- default `prompts.sh` to TUI; add `--cli` switch for old behaviour
- document dataset regeneration and TUI change in README
- log new parser in CHANGELOG
- tests for rawdata parser

## Testing
- `ruff check . --fix`
- `black .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b2cad79dc832e8b1f27f9ee21256f