### PR TITLE
Add automated pipeline and update parser

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -16,3 +16,9 @@
 
 - implement parse_rawdata.py with category heuristics and slot extraction; add tests
 
+- expand prompts.sh with automation pipeline (2 funcs, 169 lines)
+- add needs_update() to parse_rawdata.py (7 funcs, 147 lines)
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -27,13 +27,12 @@ Run all checks manually with:
 pre-commit run --all-files
 ```
 
-To regenerate the template dataset in verbatim mode:
+Use `./prompts.sh --pipeline` to parse `rawdata.txt`, lint the repository, and run all tests automatically.
 
-```bash
-PYTHONPATH=. python scripts/parse_rawdata.py --write --trim-sentences 1
-```
+`prompts.sh` launches the TUI by default. Use `--cli` for a minimal CLI mode or `--pipeline` for automation.
 
-`prompts.sh` launches the TUI by default. Use `--cli` to run the minimal CLI mode.
+
+
 
 
 

--- a/prompts.sh
+++ b/prompts.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# promptlib.sh - Production-ready shell wrapper for promptlib.py
-set -euo
+# promptlib.sh - Production-ready shell wrapper for promptlib.py and pipeline
+set -euo pipefail
 
 # -----------
 # CONFIGURATION
@@ -18,7 +18,7 @@ mkdir -p "$DATA_HOME"
 # -----------
 
 usage() {
-    printf 'Usage: %s [--cli --category <category> [--count N] [--output FILE]] [--no-color] [--dry-run]\n' "$0"
+    printf 'Usage: %s [--cli --category <category> [--count N] [--output FILE]] [--pipeline] [--no-color] [--dry-run]\n' "$0"
     printf '\n'
     printf '  --cli                    Run minimal CLI instead of default TUI\n'
     printf '  --category <category>    Category key for CLI mode\n'
@@ -26,6 +26,7 @@ usage() {
     printf '  --output FILE            Output file saved under %s\n' "$DATA_HOME"
     printf '  --no-color               Disable cyan output highlighting\n'
     printf '  --dry-run                Print command without executing\n'
+    printf '  --pipeline               Run full automation pipeline\n'
     printf '\n'
     printf 'Available categories:\n'
     "$PYTHON_BIN" "$TUI_SCRIPT" --simple-cli --list-categories
@@ -41,6 +42,7 @@ COUNT=5
 OUTPUT=""
 NO_COLOR=0
 DRY_RUN=0
+PIPELINE=0
 
 while [ "$#" -gt 0 ]; do
     key="$1"
@@ -69,6 +71,10 @@ while [ "$#" -gt 0 ]; do
             DRY_RUN=1
             shift
             ;;
+        --pipeline)
+            PIPELINE=1
+            shift
+            ;;
         -h|--help)
             usage
             exit 0
@@ -82,8 +88,32 @@ while [ "$#" -gt 0 ]; do
 done
 
 # -----------
+# PIPELINE FUNCTION
+# -----------
+
+run_pipeline() {
+    REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+    CMD="${PYTHON_BIN} ${REPO_DIR}/scripts/parse_rawdata.py --force"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '[DRY-RUN] %s\n' "$CMD"
+    else
+        eval "$CMD"
+    fi
+    FILES=$(git ls-files '*.py' '*.sh')
+    ./0-tests/codex-merge-clean.sh $FILES
+    ruff --fix .
+    black .
+    PYTHONPATH=. pytest -q
+}
+
+# -----------
 # MAIN LOGIC
 # -----------
+
+if [ "$PIPELINE" -eq 1 ]; then
+    run_pipeline
+    exit $?
+fi
 
 if [ "$CLI_MODE" -eq 0 ]; then
     set -- "$PYTHON_BIN" "$TUI_SCRIPT"
@@ -135,5 +165,8 @@ else
         printf '%s [ERROR] exit=%s\n' "$(date -Is)" "$STATUS" >>"$LOG_FILE"
     fi
 fi
+
+
+
 
 

--- a/tests/test_rawdata_parse.py
+++ b/tests/test_rawdata_parse.py
@@ -27,3 +27,16 @@ def test_no_duplicate_slot_values():
     for cat, slot_map in slots.items():
         for values in slot_map.values():
             assert len(values) == len(set(values))
+
+
+def test_needs_update(tmp_path):
+    raw = tmp_path / "raw.txt"
+    raw.write_text("x")
+    assert parse_rawdata.needs_update(str(raw), str(tmp_path))
+    parse_rawdata.write_outputs({"a": "b"}, {"a": {}}, str(tmp_path))
+    assert not parse_rawdata.needs_update(str(raw), str(tmp_path))
+    import time
+
+    time.sleep(1)
+    raw.write_text("y")
+    assert parse_rawdata.needs_update(str(raw), str(tmp_path))


### PR DESCRIPTION
## Summary
- extend `prompts.sh` with a `--pipeline` option to run dataset parsing, linting and tests
- enhance `parse_rawdata.py` with `needs_update()` helper and `--force` flag
- document the new pipeline usage in `README.md`
- record changes in `CHANGELOG.md`
- add regression tests for `needs_update`

## Testing
- `ruff check --fix .`
- `black .`
- `PYTHONPATH=. pytest -q`
- `pre-commit` *(fails: command not found)*
- `shellcheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dcca3168c832e967c99b8a359f6e5