### PR TITLE
Implement self-healing prompts.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Run all checks manually with:
 pre-commit run --all-files
 ```
 
-Use `./prompts.sh --pipeline` to parse `rawdata.txt`, lint the repository, and run all tests automatically.
+Run `./prompts.sh --category <cat>` to regenerate `dataset/templates.json` if needed and launch the prompt interface.
 
-`prompts.sh` launches the TUI by default. Use `--cli` for a minimal CLI mode or `--pipeline` for automation.
+Specify `--count N` and `--output FILE` for batch mode. The script is self-healing and requires no additional flags.
+
 
 
 


### PR DESCRIPTION
## Summary
- remove CLI/TUI switches from prompts.sh
- regenerate templates on demand using parse_rawdata
- document new usage in README

## Testing
- `ruff check --fix .`
- `black .`
- `pytest -q`
- `shellcheck -x prompts.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864305feda0832e942da27bd8d5ba6f