### PR TITLE
Implement slot previews and regenerate feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run the CLI via:
 ./prompts.sh
 ```
 
-All categories and slots are loaded dynamically from `dataset/templates.json`. Updating the dataset automatically updates the menu options without code changes.
+All categories and slots are loaded dynamically from `dataset/templates.json`. The category selector previews available slots, and previews can be regenerated until you save. Updating the dataset automatically updates the menu options without code changes.
 
 ## Development Workflow
 

--- a/tests/test_promptlib_cli_utils.py
+++ b/tests/test_promptlib_cli_utils.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import promptlib_cli as cli
+
+
+def test_get_category_choices():
+    cats = cli.get_category_choices()
+    templates, _ = cli.load_data()
+    assert set(cats) == set(templates.keys())
+
+
+def test_slot_preview_contains_slot():
+    _, slots = cli.load_data()
+    text = cli._slot_preview("insertion_oral_mouth", slots)
+    assert "OBJECT" in text
+
+
+def test_ensure_output_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = cli.ensure_output_dir("example")
+    assert Path(out).is_dir()


### PR DESCRIPTION
## Summary
- add cached data loader and slot preview utilities
- show slot previews during category selection
- allow prompt regeneration until saved
- test new CLI utilities
- document preview behavior in README

## Testing
- `ruff check --fix .`
- `black .`
- `shellcheck prompts.sh`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c7f337a8832e951f7ba5cbca67f0