### PR TITLE
Add canonical_cli for dataset inspection

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -24,3 +24,4 @@
 
 
 
+- add canonical_cli utility and new list functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## Unreleased
+- add canonical_cli utility and listing helpers per CODEX

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains utilities for generating red-team prompt mutations. The
    pip install pre-commit ruff black pytest shellcheck
    ```
 2. Install the pre-commit hooks:
+
    ```bash
    pre-commit install
    ```
@@ -23,6 +24,16 @@ Run the CLI via:
 ```
 
 All categories and slots are loaded dynamically via `canonical_loader.py`, which reads `dataset/templates.json` and merges any plugin packs in `plugins/`. The category selector previews available slots, and previews can be regenerated until you save. Updating the dataset or plugin directory hot-reloads the available options without code changes.
+
+### Inspecting the canonical dataset
+
+Use `canonical_cli.py` to list categories or inspect slots for a category. This tool relies on `canonical_loader.py` as required by CODEX.
+
+```bash
+./canonical_cli.py --list-categories
+./canonical_cli.py --show-slots pose
+```
+
 
 ## Development Workflow
 

--- a/canonical_cli.py
+++ b/canonical_cli.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""CLI for inspecting canonical prompt data.
+
+This tool relies on ``canonical_loader`` per CODEX and AGENTS
+to ensure all options come from the canonical chain.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from canonical_loader import list_categories, list_slots
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Canonical dataset inspector")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--list-categories",
+        action="store_true",
+        help="List available prompt categories",
+    )
+    group.add_argument(
+        "--show-slots",
+        metavar="CATEGORY",
+        help="Show slots for the given category",
+    )
+    args = parser.parse_args()
+
+    if args.list_categories:
+        for cat in list_categories():
+            print(cat)
+        return
+
+    slots = list_slots(args.show_slots)
+    if not slots:
+        print(f"Unknown category: {args.show_slots}", file=sys.stderr)
+        sys.exit(1)
+    for slot, values in slots.items():
+        joined = ", ".join(values)
+        print(f"{slot}: {joined}")
+
+
+if __name__ == "__main__":
+    main()

--- a/canonical_loader.py
+++ b/canonical_loader.py
@@ -70,3 +70,19 @@ def load_options(path: str | None = None) -> dict:
     data = json.loads(opt_path.read_text(encoding="utf-8"))
     _OPTS_CACHE[str(opt_path)] = (mtime, data)
     return data
+
+
+def list_categories(
+    config_path: str | None = None, plugin_dir: str | None = None
+) -> list[str]:
+    """Return sorted category names from the canonical dataset."""
+    templates, _, _ = load_canonical(config_path, plugin_dir)
+    return sorted(templates.keys())
+
+
+def list_slots(
+    category: str, config_path: str | None = None, plugin_dir: str | None = None
+) -> dict:
+    """Return slot mapping for a given category from the canonical dataset."""
+    _, slots, _ = load_canonical(config_path, plugin_dir)
+    return slots.get(category, {})

--- a/tests/test_canonical_cli.py
+++ b/tests/test_canonical_cli.py
@@ -1,0 +1,22 @@
+import json
+import canonical_loader as cl
+
+
+def test_list_categories(tmp_path):
+    data = {"templates": {"pose": "t"}, "slots": {"pose": {"tag": ["a"]}}}
+    cfg = tmp_path / "templates.json"
+    cfg.write_text(json.dumps(data), encoding="utf-8")
+    plugdir = tmp_path / "plugins"
+    plugdir.mkdir()
+    cats = cl.list_categories(str(cfg), str(plugdir))
+    assert cats == ["pose"]
+
+
+def test_list_slots(tmp_path):
+    data = {"templates": {"pose": "t"}, "slots": {"pose": {"tag": ["a"]}}}
+    cfg = tmp_path / "templates.json"
+    cfg.write_text(json.dumps(data), encoding="utf-8")
+    plugdir = tmp_path / "plugins"
+    plugdir.mkdir()
+    slots = cl.list_slots("pose", str(cfg), str(plugdir))
+    assert slots == {"tag": ["a"]}


### PR DESCRIPTION
## Summary
- add a helper CLI `canonical_cli.py` following CODEX/AGENTS
- expose `list_categories` and `list_slots` in `canonical_loader`
- document the new tool in README
- track changes in CHANGELOGs
- add unit tests for new helpers

## Testing
- `ruff check --fix .`
- `black --check .`
- `shellcheck -x prompts.sh 0-tests/codex-merge-clean.sh 0-tests/codex-generate.sh`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868b266197c832e89b6fd1f894b4ee7