### PR TITLE
Sprint 1 setup and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,15 @@ jobs:
       - name: Install deps
         if: steps.changed.outputs.any_changed == 'true'
         run: |
-          pip install pre-commit
+          sudo apt-get update -y
+          sudo apt-get install -y bats fzf shellcheck
+          pip install pre-commit pyyaml prompt_toolkit pytest-cov coverage
       - name: Run pre-commit
         if: steps.changed.outputs.any_changed == 'true'
         run: pre-commit run --show-diff-on-failure --color always --files ${{ steps.changed.outputs.all_changed_files }}
+      - name: Coverage XML
+        if: steps.changed.outputs.any_changed == 'true'
+        run: coverage xml
       - name: Skip checks
         if: steps.changed.outputs.any_changed == 'false'
         run: echo "Documentation-only change; skipping checks."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,15 @@ jobs:
           python-version: '3.11'
       - name: Build tarball
         run: tar -czf prompts.tar.gz bin lib
+      - name: Build Docker image
+        run: docker build -t prompts .
+      - name: Generate SBOM
+        run: |
+          pip install cyclonedx-bom
+          cyclonedx-py -o sbom.xml
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
-          files: prompts.tar.gz
+          files: |
+            prompts.tar.gz
+            sbom.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,14 @@ repos:
         files: ''
       - id: pytest
         name: pytest
-        entry: bash -c 'PYTHONPATH=. pytest -q'
+        entry: bash -c 'PYTHONPATH=. pytest -q --cov=.'
         language: system
         types: [python]
+      - id: bats
+        name: bats
+        entry: bash -c 'bats -r test/test_scripts.bats'
+        language: system
+        types: [shell]
       - id: shellcheck
         name: ShellCheck (bash)
         entry: shellcheck -x

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: setup test bats validate clean
+
+setup:
+python3 -m pip install --upgrade pip
+pip install -r requirements.txt pre-commit
+sudo apt-get update -y
+sudo apt-get install -y fzf shellcheck bats
+pre-commit install
+
+test:
+PYTHONPATH=. pytest -q --cov=.
+
+bats:
+bats -r test/test_scripts.bats
+
+validate:
+python scripts/parse_rawdata.py --write
+
+clean:
+find . -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -9,8 +9,21 @@ make setup
 bin/prompts.sh
 ```
 
+## Usage
+
+The `prompts.sh` wrapper allows you to generate prompts from the canonical
+dataset. Select a category when prompted and the resulting text will be copied
+to your clipboard (if `xclip` is available).
+
+## Setup
+
+Run `make setup` to install Python requirements and common tooling such as
+`bats`, `fzf` and `shellcheck`. Pre-commit hooks are installed automatically.
+
 ## Architecture
 
 ![architecture](docs/architecture.png)
 
-See `docs/ADR-0001.md` for design decisions.
+The system is composed of simple shell wrappers that call into Python utilities
+for loading the dataset and plugins. See `docs/ADR-0001.md` for full design
+decisions.

--- a/bin/choose_prompt.sh
+++ b/bin/choose_prompt.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-templates_file="${1:-data/templates.yaml}"
+choice=$(
+	python3 - <<'PY'
+from canonical_loader import list_categories
+for c in list_categories():
+    print(c)
+PY
+)
 
-if ! [ -f "$templates_file" ]; then
-	echo "Templates file not found: $templates_file" >&2
-	exit 1
-fi
-
-choice=$(grep -o '^[^:]*' "$templates_file" | fzf --prompt='Template > ' --height=40% --border) || exit 1
+choice=$(printf '%s\n' "$choice" | fzf --prompt='Category > ' --height=40% --border) || exit 1
 printf '%s\n' "$choice"

--- a/bin/prompts.sh
+++ b/bin/prompts.sh
@@ -4,21 +4,20 @@ set -euo pipefail
 IFS=$'\n\t'
 
 choice=$(bin/choose_prompt.sh)
-template_key="$choice"
 
 prompt=$(
-	python3 - "$template_key" <<'PY'
+	python3 - "$choice" <<'PY'
 import sys
-import yaml
-from lib.promptgen import generate_prompt
+from canonical_loader import load_canonical
+from prompt_config import generate_prompt
 
-with open('data/templates.yaml') as f:
-    templates = yaml.safe_load(f)
-with open('data/slots.yaml') as f:
-    slots = yaml.safe_load(f)
-
+templates, slots, _ = load_canonical()
 key = sys.argv[1]
-print(generate_prompt(templates[key], slots))
+template = templates.get(key)
+slotset = slots.get(key, {})
+if template is None:
+    raise SystemExit(f"Unknown category: {key}")
+print(generate_prompt(template, slotset))
 PY
 )
 

--- a/data/slots.yaml
+++ b/data/slots.yaml
@@ -1,1 +1,0 @@
-name: World

--- a/data/templates.yaml
+++ b/data/templates.yaml
@@ -1,2 +1,10 @@
-hello: "Hello {name}"
-goodbye: "Goodbye {name}"
+templates:
+  hello: "Hello [name]"
+  goodbye: "Goodbye [name]"
+slots:
+  hello:
+    name:
+      - World
+  goodbye:
+    name:
+      - World

--- a/prompt_config.py
+++ b/prompt_config.py
@@ -3,14 +3,14 @@
 
 from __future__ import annotations
 
-import json
+import yaml
 import os
 import random
 from typing import Dict
 
 _CACHE: dict[str, tuple[Dict[str, str], Dict[str, Dict[str, list]]]] = {}
 
-CONFIG_PATH = os.path.join(os.path.dirname(__file__), "dataset", "templates.json")
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "data", "templates.yaml")
 
 
 def load_config(
@@ -23,7 +23,7 @@ def load_config(
     abspath = os.path.abspath(path)
     if abspath not in _CACHE:
         with open(abspath, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
+            data = yaml.safe_load(fh)
         templates = data.get("templates", {})
         slots = data.get("slots", {})
         _CACHE[abspath] = (templates, slots)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pyyaml
+prompt_toolkit
+pytest
+pytest-cov
+coverage

--- a/tests/test_promptlib_cli_utils.py
+++ b/tests/test_promptlib_cli_utils.py
@@ -11,8 +11,8 @@ def test_get_category_choices():
 
 def test_slot_preview_contains_slot():
     cfg = cli.load_dict()
-    text = cli._slot_preview("insertion_oral_mouth", cfg)
-    assert "OBJECT" in text
+    text = cli._slot_preview("hello", cfg)
+    assert "name" in text.lower()
 
 
 def test_ensure_output_dir(tmp_path, monkeypatch):

--- a/tickets/50-001.md
+++ b/tickets/50-001.md
@@ -1,0 +1,6 @@
+# 50-001 - SHE - Align CLI with unified dataset format
+- **Stream**: SHE
+- **Title**: Align CLI with unified dataset format
+- **Dependencies**: 10-005, 10-004
+- **Priority**: P0
+- **Estimated hours**: 3

--- a/tickets/50-002.md
+++ b/tickets/50-002.md
@@ -1,0 +1,6 @@
+# 50-002 - DOC - Complete README and usage docs
+- **Stream**: DOC
+- **Title**: Complete README and usage docs
+- **Dependencies**: 20-001
+- **Priority**: P0
+- **Estimated hours**: 4

--- a/tickets/50-003.md
+++ b/tickets/50-003.md
@@ -1,0 +1,6 @@
+# 50-003 - SHE - Cross-platform clipboard support (Win/Mac)
+- **Stream**: SHE
+- **Title**: Cross-platform clipboard support (Win/Mac)
+- **Dependencies**: 30-001
+- **Priority**: P1
+- **Estimated hours**: 4

--- a/tickets/50-004.md
+++ b/tickets/50-004.md
@@ -1,0 +1,6 @@
+# 50-004 - CI - Add release workflow & container build
+- **Stream**: CI
+- **Title**: Add release workflow & container build
+- **Dependencies**: 20-003, 10-007
+- **Priority**: P1
+- **Estimated hours**: 5

--- a/tickets/50-005.md
+++ b/tickets/50-005.md
@@ -1,0 +1,6 @@
+# 50-005 - QA - Integrate Bats & coverage in CI
+- **Stream**: QA
+- **Title**: Integrate Bats & coverage in CI
+- **Dependencies**: 10-006
+- **Priority**: P1
+- **Estimated hours**: 2

--- a/tickets/50-006.md
+++ b/tickets/50-006.md
@@ -1,0 +1,6 @@
+# 50-006 - QA - Generate SBOM and document threat model
+- **Stream**: QA
+- **Title**: Generate SBOM and document threat model
+- **Dependencies**: 10-007
+- **Priority**: P2
+- **Estimated hours**: 3

--- a/tickets/50-007.md
+++ b/tickets/50-007.md
@@ -1,0 +1,6 @@
+# 50-007 - ARC - ADR-0001: Plugin system guidelines
+- **Stream**: ARC
+- **Title**: ADR-0001: Plugin system guidelines
+- **Dependencies**: 30-003
+- **Priority**: P2
+- **Estimated hours**: 2

--- a/tickets/50-008.md
+++ b/tickets/50-008.md
@@ -1,0 +1,6 @@
+# 50-008 - PYL - Schema validation for dataset config
+- **Stream**: PYL
+- **Title**: Schema validation for dataset config
+- **Dependencies**: 30-002, 50-001
+- **Priority**: P3
+- **Estimated hours**: 3

--- a/tickets/60-001.md
+++ b/tickets/60-001.md
@@ -1,0 +1,6 @@
+# 60-001 - INF - Add `.gitignore` and cleanup repository hygiene
+- **Stream**: INF
+- **Title**: Add `.gitignore` and cleanup repository hygiene
+- **Dependencies**: 10-001
+- **Priority**: P1
+- **Estimated hours**: 1

--- a/tickets/60-002.md
+++ b/tickets/60-002.md
@@ -1,0 +1,6 @@
+# 60-002 - DOC - Finalize Man-Page (`prompts.1.scd`)
+- **Stream**: DOC
+- **Title**: Finalize Man-Page (`prompts.1.scd`)
+- **Dependencies**: 20-002, 50-002
+- **Priority**: P1
+- **Estimated hours**: 2

--- a/tickets/60-003.md
+++ b/tickets/60-003.md
@@ -1,0 +1,6 @@
+# 60-003 - INF - Implement `make setup` and `Makefile`
+- **Stream**: INF
+- **Title**: Implement `make setup` and `Makefile`
+- **Dependencies**: 50-002
+- **Priority**: P1
+- **Estimated hours**: 2

--- a/tickets/60-004.md
+++ b/tickets/60-004.md
@@ -1,0 +1,6 @@
+# 60-004 - INF - Purge stale `__pycache__` directories
+- **Stream**: INF
+- **Title**: Purge stale `__pycache__` directories
+- **Dependencies**: 50-001
+- **Priority**: P1
+- **Estimated hours**: 1

--- a/tickets/60-005.md
+++ b/tickets/60-005.md
@@ -1,0 +1,6 @@
+# 60-005 - QA - Complete integration tests (end-to-end flow)
+- **Stream**: QA
+- **Title**: Complete integration tests (end-to-end flow)
+- **Dependencies**: 50-005
+- **Priority**: P1
+- **Estimated hours**: 3

--- a/tickets/60-006.md
+++ b/tickets/60-006.md
@@ -1,0 +1,6 @@
+# 60-006 - DOC - Finalize Architecture ADR (ADR-0001.md)
+- **Stream**: DOC
+- **Title**: Finalize Architecture ADR (ADR-0001.md)
+- **Dependencies**: 50-007
+- **Priority**: P1
+- **Estimated hours**: 2

--- a/tickets/60-007.md
+++ b/tickets/60-007.md
@@ -1,0 +1,6 @@
+# 60-007 - INF - Clean dataset directory (remove `nsfwprompts.txt` if unused)
+- **Stream**: INF
+- **Title**: Clean dataset directory (remove `nsfwprompts.txt` if unused)
+- **Dependencies**: 50-001
+- **Priority**: P2
+- **Estimated hours**: 1

--- a/tickets/60-008.md
+++ b/tickets/60-008.md
@@ -1,0 +1,6 @@
+# 60-008 - INF - Standardize YAML/JSON dataset conversion script
+- **Stream**: INF
+- **Title**: Standardize YAML/JSON dataset conversion script
+- **Dependencies**: 50-001
+- **Priority**: P2
+- **Estimated hours**: 2


### PR DESCRIPTION
## Summary
- add missing tickets for 50-* and 60-* series
- integrate pre-commit with coverage and Bats in CI
- add release workflow steps for Docker and SBOM
- unify CLI with canonical dataset
- update README and provide Makefile for environment bootstrap

## Testing
- `ruff check --fix prompt_config.py tests/test_promptlib_cli_utils.py`
- `black prompt_config.py tests/test_promptlib_cli_utils.py`
- `shellcheck -x bin/choose_prompt.sh bin/prompts.sh`
- `shfmt -w bin/choose_prompt.sh bin/prompts.sh`
- `PYTHONPATH=. pytest -q --cov=.`
- `bats -r test/test_scripts.bats`
- `coverage xml`


------
https://chatgpt.com/codex/tasks/task_e_686b2a49e978832ea3926de1e84bc950