### PR TITLE
Initialize tickets for missing Sprint 1 items

### DIFF
--- a/tickets/50-009.md
+++ b/tickets/50-009.md
@@ -1,0 +1,8 @@
+# 50-009 - PYL - Implement "sora_closeup_portrait" template (+ slots)
+- **Stream**: PYL
+- **Title**: Implement "sora_closeup_portrait" template (+ slots)
+- **Dependencies**: 50-001
+- **Priority**: P0
+- **Estimated hours**: 2
+
+

--- a/tickets/50-010.md
+++ b/tickets/50-010.md
@@ -1,0 +1,8 @@
+# 50-010 - SHE - Slot-by-slot interactive UX for `prompts.sh`
+- **Stream**: SHE
+- **Title**: Slot-by-slot interactive UX for `prompts.sh`
+- **Dependencies**: 50-009
+- **Priority**: P0
+- **Estimated hours**: 3
+
+


### PR DESCRIPTION
## Summary
- add missing ticket files for sora template and interactive prompts UX
- normalize EOF newlines in ticket docs

## Testing
- `pre-commit run --files tickets/50-009.md tickets/50-010.md`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c675d717c832e9e961b78b87f8ed4